### PR TITLE
Cleanup after running in production for a few weeks

### DIFF
--- a/lib/rules/assets.js
+++ b/lib/rules/assets.js
@@ -58,7 +58,7 @@ module.exports = exports = function(payload, fn) {
       if(!har.log.entries) return fn(null);
 
       // awesome so first we check all the entries in our HAR
-      async.eachLimit(har.log.entries || [], 20, function(entry, cb) {
+      async.eachLimit(har.log.entries || [], 5, function(entry, cb) {
 
         // sanity checks
         if(!entry) return cb(null);

--- a/lib/rules/links.js
+++ b/lib/rules/links.js
@@ -41,12 +41,13 @@ module.exports = exports = function(payload, fn) {
 
     // list of links that we found to test
     var testableLinks   = [];
+    var testingSlugs    = [];
 
     // local cheerio instance for lookups
     var $ = cheerio.load(content);
 
     // get all the links
-    $('a').each(function(i, elem) {
+    $('body a').each(function(i, elem) {
 
       // ref of the link
       var href = $(elem).attr('href');
@@ -86,13 +87,17 @@ module.exports = exports = function(payload, fn) {
             return;
 
       // the final ref
-      var hrefTarget = url.format(hrefUri);
+      var hrefTarget    = url.format(hrefUri);
+      var hrefSlugged   = S(hrefTarget).slugify().s;
 
       // sanity check
       if(S(hrefTarget || '').isEmpty() === true) return;
 
       // avoid dups
-      if(testableLinks.indexOf(hrefTarget) != -1) return;
+      if(testingSlugs.indexOf(hrefSlugged) != -1) return;
+
+      // add it
+      testingSlugs.push(hrefSlugged);
 
       // add the link
       testableLinks.push({
@@ -141,7 +146,7 @@ module.exports = exports = function(payload, fn) {
       payload.doRequest({
 
         url:      link.url,
-        type:     'HEAD',
+        type:     'GET',
         session:  data.session
 
       }, function(err, response, body) {
@@ -158,7 +163,7 @@ module.exports = exports = function(payload, fn) {
           
           // set the message
           params.identifiers      = [ link.url, 10 ]
-          params.message          = 'HEAD request to $ timed out after $ seconds'
+          params.message          = 'GET request to $ timed out after $ seconds'
 
           // add each rule
           payload.addRule({
@@ -177,7 +182,7 @@ module.exports = exports = function(payload, fn) {
           
           // set the message
           params.identifiers      = [ link.url ]
-          params.message          = 'Unable to verify that $ is working with HEAD request'
+          params.message          = 'Unable to verify that $ is working with GET request'
 
           // add each rule
           payload.addRule({

--- a/lib/rules/secure.js
+++ b/lib/rules/secure.js
@@ -48,8 +48,6 @@ module.exports = exports = function(payload, fn) {
     // get the page content
     payload.getHAR(function(err, har) {
 
-      console.dir(har)
-
       // did we get a error ?
       if(err) {
 

--- a/test/links.js
+++ b/test/links.js
@@ -106,7 +106,7 @@ describe('links', function() {
 
       url: 'http://example.com'
 
-    }, { log: { entries: [] } }, '<p><a href="#">TEST</a></p>');
+    }, { log: { entries: [] } }, '<p><a href="#">TEST</a></p></body>');
 
     // execute the items
     testFunc(payload, function(err) {
@@ -138,7 +138,7 @@ describe('links', function() {
 
       url: 'http://example.com'
 
-    }, { log: { entries: [] } }, '<p><a href="javascript:void();">TEST</a></p>');
+    }, { log: { entries: [] } }, '<p><a href="javascript:void();">TEST</a></p></body>');
 
     // execute the items
     testFunc(payload, function(err) {
@@ -170,7 +170,7 @@ describe('links', function() {
 
       url: 'http://example.com'
 
-    }, { log: { entries: [] } }, '<p><a href="test();">TEST</a></p>');
+    }, { log: { entries: [] } }, '<p><a href="test();">TEST</a></p></body>');
 
     // execute the items
     testFunc(payload, function(err) {
@@ -226,7 +226,7 @@ describe('links', function() {
 
           url: 'http://example.com'
 
-        }, { log: { entries: [] } }, '<p><a href="http://localhost:' + serverPort + '/hello">TEST</a></p>');
+        }, { log: { entries: [] } }, '<body><p><a href="http://localhost:' + serverPort + '/hello">TEST</a></p></body>');
 
         // execute the items
         testFunc(payload, function(err) {
@@ -302,7 +302,7 @@ describe('links', function() {
 
           url: 'http://example.com'
 
-        }, { log: { entries: [] } }, '<p><a href="http://localhost:' + serverPort + '/hello">TEST</a></p>');
+        }, { log: { entries: [] } }, '<body><p><a href="http://localhost:' + serverPort + '/hello">TEST</a></p></body>');
 
         // execute the items
         testFunc(payload, function(err) {


### PR DESCRIPTION
Few updates that we spotted while running in production, namely:

* Some servers just straight up disable HEAD requests ... Had to change to GET requests
* Added caching for those links in a session
* Limited the amount of links we check at the same time
* Removed logging information that was clogging up our logs with useless information