### PR TITLE
Release v1.0.15

### DIFF
--- a/lib/rules/links.js
+++ b/lib/rules/links.js
@@ -214,7 +214,7 @@ module.exports = exports = function(payload, fn) {
                   statusCode !== 405 &&
                     statusCode !== 403 &&
                       statusCode > 400 && 
-                        statusCode <= 600) {
+                        statusCode <= 500) {
 
           // set the message
           params.identifiers    =   [ link.url, statusCode ];

--- a/lib/rules/secure.js
+++ b/lib/rules/secure.js
@@ -14,7 +14,7 @@ module.exports = exports = function(payload, fn) {
   var data = payload.getData();
 
   // parse the url
-  var uri = url.parse(data.redirected || data.url);
+  var uri = url.parse(data.url);
 
   // if the page is not https, we skip ...
   if((uri.protocol || '').indexOf('https') != 0) {

--- a/test/links.js
+++ b/test/links.js
@@ -267,7 +267,7 @@ describe('links', function() {
   });
 
   // handle the error output
-  it('Should return a error if the link returns a status between 400 and 600', function(done) {
+  it('Should return a error if the link returns a status between 400 and <500', function(done) {
 
     // we are actually starting servers, so just in case
     // we test on Travis etc with smaller boxes
@@ -277,7 +277,7 @@ describe('links', function() {
     var statusCodes = [];
 
     // loop
-    for(var i = 405; i < 601; i++) { 
+    for(var i = 405; i < 499; i++) { 
 
       if(i === 405) continue;
       statusCodes.push(i); 


### PR DESCRIPTION
Maintenance that makes the checker a bit more forgiving to links.

Our servers seem to check links way to fast for some servers, so want to able to handle this on the reports nicely. Opting rather to just ignore the 500 errors then and looking for 400, mainly 403/404's for now.