### PR TITLE
Trim HREF

### DIFF
--- a/lib/rules/assets.js
+++ b/lib/rules/assets.js
@@ -66,7 +66,7 @@ module.exports = exports = function(payload, fn) {
         if(!entry.response) return cb(null);
 
         // get the url
-        var entryUrl = entry.request.url;
+        var entryUrl = S(entry.request.url).trim().s;
         var entryUri = url.parse(entry.request.url);
 
         // sanity check

--- a/lib/rules/links.js
+++ b/lib/rules/links.js
@@ -50,7 +50,7 @@ module.exports = exports = function(payload, fn) {
     $('body a').each(function(i, elem) {
 
       // ref of the link
-      var href = $(elem).attr('href');
+      var href = S($(elem).attr('href') || '').trim().s;
 
       // double check that we got a ref ...
       if(S(href || '').isEmpty() === true) return;


### PR DESCRIPTION
Had an issue where the HREF's are not trimmed, and when we try to check them and convert to absolute we got the dreaded double URL.

This patch just adds trimming to the URLS it gets from the `href` property which clears up the issue.

See https://passmarked.com/reports/20170614e0fea090114452P?source=slack.internal.activity&section=content&category=content&rule=link&test=links for a example of this.