### PR TITLE
Release v1.0.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - '6.2'
   - '5.1'
   - '4.2'
-  - '0.12'
 addons:
   apt:
     sources:

--- a/lib/rules/assets.js
+++ b/lib/rules/assets.js
@@ -66,7 +66,7 @@ module.exports = exports = function(payload, fn) {
         if(!entry.response) return cb(null);
 
         // get the url
-        var entryUrl = entry.request.url;
+        var entryUrl = S(entry.request.url).trim().s;
         var entryUri = url.parse(entry.request.url);
 
         // sanity check

--- a/lib/rules/links.js
+++ b/lib/rules/links.js
@@ -50,7 +50,7 @@ module.exports = exports = function(payload, fn) {
     $('body a').each(function(i, elem) {
 
       // ref of the link
-      var href = $(elem).attr('href');
+      var href = S($(elem).attr('href') || '').trim().s;
 
       // double check that we got a ref ...
       if(S(href || '').isEmpty() === true) return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passmarked/links",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Rules related to the links/assets on the page",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passmarked/links",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Rules related to the links/assets on the page",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "async": "^2.1.4",
-    "cheerio": "^0.22.0",
+    "async": "^2.4.1",
+    "cheerio": "^1.0.0-rc.1",
     "passmarked": "*",
-    "request": "^2.79.0",
+    "request": "^2.81.0",
     "string": "^3.3.3",
     "underscore": "^1.8.3",
-    "when": "^3.7.7",
+    "when": "^3.7.8",
     "yslow": "^3.1.0"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^3.2.0"
+    "chai": "^4.0.2",
+    "mocha": "^3.4.2"
   }
 }


### PR DESCRIPTION
Maintenance release with a bug fix:

* Updated the dependency versions to latest
* Added URL stripping to handle edge cases with websites adding in a " " before URLS ...
* Removed Node 0.12 as deprecated and we no longer need to support it.